### PR TITLE
Fix highlighting for source code entries

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
                { src: 'reveal.js/lib/js/classList.js', condition: function() { return !document.body.classList; } },
                { src: 'reveal.js/plugin/markdown/marked.js', condition: function() { return !!document.querySelector( '[data-markdown]' ); } },
                { src: 'reveal.js/plugin/markdown/markdown.js', condition: function() { return !!document.querySelector( '[data-markdown]' ); } },
-               { src: 'reveal.js/plugin/highlight/highlight.js', async: true, condition: function() { return !!document.querySelector( 'pre code' ); }, callback: function() { hljs.initHighlightingOnLoad(); } },
+               { src: 'reveal.js/plugin/highlight/highlight.js', async: true, callback: function() { hljs.initHighlightingOnLoad(); } },
                { src: 'reveal.js/plugin/zoom-js/zoom.js', async: true },
                { src: 'reveal.js/plugin/notes/notes.js', async: true }
             ]


### PR DESCRIPTION
This had previously been fixed upstream by
reveal.js by d44bcdb3ffacf59f407b250d51ad688a60f90318, however,
had not been merged into our version of index.html.
